### PR TITLE
Added support of gnome 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     "original-author": "Franjo Filo <fffilo666@gmail.com>",
     "original-author-html": "Franjo Filo &lt;<a href=\"mailto:fffilo666@gmail.com\">fffilo666@gmail.com</a>&gt;",
     "settings-schema": "org.gnome.shell.extensions.prime-indicator",
-    "shell-version": ["40"],
+    "shell-version": ["42"],
     "url": "https://github.com/fffilo/prime-indicator",
     "uuid": "prime-indicator@gnome-shell-exstensions.fffilo.github.com",
     "version": "9"


### PR DESCRIPTION
To activate the extension under Gnome 42, the shell version need to be updated to 42 to let the extension manager to activate it without warning the user of the incompatibility. (The extension work perfectly well with just this simple fix under gnome 42)